### PR TITLE
Fix incorrect level check returning a false positive

### DIFF
--- a/src/TelegramLogHandler.php
+++ b/src/TelegramLogHandler.php
@@ -54,7 +54,7 @@ class TelegramLogHandler extends AbstractProcessingHandler
             Cache::put($cache_key, get_class($e), $this->cache_ttl);
         }
 
-        return true;
+        return parent::isHandling($record);
     }
 
     /**


### PR DESCRIPTION
Irrespective of which 'level' you set in config, all logs are sent to telegram.

In TelegramLogHandler, the $level is passed to the parent constructor, and the level check is performed by the parent's parent.

In TelegramLogHandler::isHandling, instead of returning true, it should return the parents' decision via

return parent::isHandling($record);